### PR TITLE
Fix text size in position component

### DIFF
--- a/components/content/position.tsx
+++ b/components/content/position.tsx
@@ -25,7 +25,7 @@ const Position: React.FC<PositionProps> = ({
         <div className="flex justify-between mb-0.5">
           <p>
             <span className="font-semibold text-xl">{title}</span>
-            <span className="text-l">, {company}</span>
+            <span className="text-lg">, {company}</span>
           </p>
           <p className="text-sm text-gray-600">{timeframe}</p>
         </div>


### PR DESCRIPTION
## Summary
- correct `text-l` typo so company names render with proper size

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c86cd64c8328b0932b41687c3568